### PR TITLE
Tighten normal mode mappings for ripgrep

### DIFF
--- a/config/nvim/lua/core/mappings.lua
+++ b/config/nvim/lua/core/mappings.lua
@@ -245,13 +245,13 @@ M.ripgrep_mappings = function()
   --  Grep project for selection with Rg
   vmap { '<leader>gr', 'y :Rg "<CR>' }
   --  Grep project for word under the cursor with Rg
-  nmap { '<Leader>gr :Rg', '<C-r><C-w><CR>' }
+  nmap { '<Leader>gr', ':Rg <C-r><C-w><CR>' }
 
   --  alias for above
   --  Grep project for selection with Rg
   vmap { '<leader>rg', 'y :Rg "<CR>' }
   --  Grep project for word under the cursor with Rg
-  nmap { '<Leader>rg :Rg', '<C-r><C-w><CR>' }
+  nmap { '<Leader>rg', ':Rg <C-r><C-w><CR>' }
 
   --  Grep selection with Rg (excluding tests and migrations)
   vmap { '<leader>gt', "y :Rg \" -g '!*/**/test/*' -g '!*/**/migrations/*'<CR>" }


### PR DESCRIPTION
## WHAT

Change the normal mode rg mappings, put `:Rg` into the command arg instead of
the map arg.

## WHY

It feels like the intention was to have `\gr` and `\rg` grab the word under cursor and
search for it.

## HOW

Just shuffle that `:Rg` onto the front of the command.
