### PR TITLE
fix(task): Create .fonts dir before install

### DIFF
--- a/taskfiles/fonts.yml
+++ b/taskfiles/fonts.yml
@@ -23,6 +23,7 @@ tasks:
           if [ "$(uname)" = "Darwin" ]; then
             echo "$HOME/Library/Fonts"
           elif [ "$(uname)" = "Linux" ]; then
+            mkdir -p "$HOME/.fonts"
             echo "$HOME/.fonts"
           else
             echo "Can't install fonts. Unsupported OS." >&2


### PR DESCRIPTION
## WHAT

Create a `$HOME/.fonts` before downloading the fonts when installing the fonts via taskfile.

## WHY

I ran into a directory does not exist error when installing fonts.

## NOTES

I don't know if this is idiomatic or not.  If this is the right thing to do, this will smooth out the `task:install` the next time that's run on linux.