### PR TITLE
Fix condition for `task` installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -52,7 +52,7 @@ if [[ $OS = 'mac' ]]; then
   ./installer/mac-setup.sh
 fi
 
-if [[ -f ~/.local/bin/task ]]; then
+if [[ ! -f ~/.local/bin/task ]]; then
   # Install task
   mkdir -p ~/.local/bin
   sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin


### PR DESCRIPTION
The prior value was only installing `task` if the `~/.local/bin/task` was already present, but I'm pretty sure you meant the opposite.

I noticed this as I'm refactoring my dotfiles to be more similar to how you have yours setup (though not 100% the same). I really like the Taskfile bits though. (/ht @rondale-sc for pointing me your way) 🤘