### PR TITLE
fix(nvim-update): Ensure MasonUpdateAll completes

### DIFF
--- a/scripts/nvim-update.sh
+++ b/scripts/nvim-update.sh
@@ -7,5 +7,5 @@ nvim \
   +'Lazy! clean' \
   +'Lazy! clear' \
   +'TSUpdateSync' \
-  +'MasonUpdateAll' \
-  +'qall!'
+  +'autocmd User MasonUpdateAllCompleted qall!' \
+  +'MasonUpdateAll'


### PR DESCRIPTION
`:MasonUpdateAll` is async, so (as written) the `:qall` will run *before* the actual mason updates have ran.

See https://github.com/Zeioth/mason-extra-cmds/blob/606ecf0cebed0f91926558158e61725d2678d90c/lua/masonextracmds/mason/utils.lua#L83-L94 for where this event is kicked off.