### PR TITLE
fix: hard-coded paths should ~ / $HOME when possible

### DIFF
--- a/config/vifm/vifmrc
+++ b/config/vifm/vifmrc
@@ -286,7 +286,7 @@ fileviewer *.doc antiword -
 fileviewer *.docx docx2txt.pl %f -
 
 fileviewer *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm
-    \ tput cup %py %px > /dev/tty && /Users/dorian/.iterm2/imgcat %c:p > /dev/tty
+    \ tput cup %py %px > /dev/tty && ~/.iterm2/imgcat %c:p > /dev/tty
 
 fileviewer * env -uCOLORTERM bat --color always --wrap never --pager never %c -p
 

--- a/config/zsh/pnpm.zsh
+++ b/config/zsh/pnpm.zsh
@@ -1,5 +1,5 @@
 # pnpm
-export PNPM_HOME="/Users/dorian/.local/share/pnpm"
+export PNPM_HOME="$HOME/.local/share/pnpm"
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;
   *) export PATH="$PNPM_HOME:$PATH" ;;


### PR DESCRIPTION
This makes things a bit more portable.

![home](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3E3ZzdvdjFraGtvOWJtdHY5ZXNsb3FsOWd0d3dzdjR1d3ZnbWwxZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/O6VoexTrRs6eQ/giphy.gif)