### PR TITLE
feat(nvim): add vim-rhubarb dependency to fugitive

### DIFF
--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -84,6 +84,7 @@
   "vim-projectionist": { "branch": "master", "commit": "5ff7bf79a6ef741036d2038a226bcb5f8b1cd296" },
   "vim-ragtag": { "branch": "master", "commit": "51b313e8a2e3a44f37b9d625bc0d461e9066b7e9" },
   "vim-repeat": { "branch": "master", "commit": "65846025c15494983dafe5e3b46c8f88ab2e9635" },
+  "vim-rhubarb": { "branch": "master", "commit": "5496d7c94581c4c9ad7430357449bb57fc59f501" },
   "vim-ripgrep": { "branch": "master", "commit": "2bb2425387b449a0cd65a54ceb85e123d7a320b8" },
   "vim-rsi": { "branch": "master", "commit": "45540637ead22f011e8215f1c90142e49d946a54" },
   "vim-rubygems": { "branch": "master", "commit": "c3445c3988304ea5eebbca21a63dc4abfd2e0167" },

--- a/config/nvim/lua/plugins/fugitive.lua
+++ b/config/nvim/lua/plugins/fugitive.lua
@@ -3,6 +3,9 @@
 return {
   'tpope/vim-fugitive',
   event = 'VeryLazy',
+  dependencies = {
+    'tpope/vim-rhubarb', -- GitHub extension for fugitive (enables :GBrowse)
+  },
   config = function()
     require('core.mappings').fugitive_mappings()
 


### PR DESCRIPTION
This enables the `:GBrowse` feature to work with GitHub.

![rhubarb](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnFxaTY1anB3Zjg4NzJrd2k2MndxYTF5eGl5cWV2cHRqYXEyYmt3dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DyuK5h9m0cucgzTr7r/giphy.gif)