### PR TITLE
feat(herdr): add seamless Neovim navigation

### DIFF
--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -41,6 +41,9 @@ includes:
     aliases: [github]
     taskfile: ./taskfiles/github.yml
 
+  herdr:
+    taskfile: ./taskfiles/herdr.yml
+
   mac:
     taskfile: ./taskfiles/mac.yml
 

--- a/config/herdr/config.toml
+++ b/config/herdr/config.toml
@@ -21,10 +21,10 @@ rows = [["state_icon", "workspace", "$pr"], ["agent"]]
 prefix = "ctrl+z"
 navigate_workspace_up = "k"
 navigate_workspace_down = "j"
-focus_pane_left = "ctrl+h"
-focus_pane_down = "ctrl+j"
-focus_pane_up = "ctrl+k"
-focus_pane_right = "ctrl+l"
+focus_pane_left = ""
+focus_pane_down = ""
+focus_pane_up = ""
+focus_pane_right = ""
 split_vertical = "prefix+\\"
 rename_pane = ""
 rename_tab = ""
@@ -37,3 +37,51 @@ key = "prefix+shift+p"
 type = "plugin_action"
 command = "dotfiles.command-palette.open"
 description = "command palette"
+
+[[keys.command]]
+key = "ctrl+h"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.navigate-left"
+description = "navigate left"
+
+[[keys.command]]
+key = "ctrl+j"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.navigate-down"
+description = "navigate down"
+
+[[keys.command]]
+key = "ctrl+k"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.navigate-up"
+description = "navigate up"
+
+[[keys.command]]
+key = "ctrl+l"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.navigate-right"
+description = "navigate right"
+
+[[keys.command]]
+key = "alt+h"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.resize-left"
+description = "resize left"
+
+[[keys.command]]
+key = "alt+j"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.resize-down"
+description = "resize down"
+
+[[keys.command]]
+key = "alt+k"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.resize-up"
+description = "resize up"
+
+[[keys.command]]
+key = "alt+l"
+type = "plugin_action"
+command = "dotfiles.seamless-navigation.resize-right"
+description = "resize right"

--- a/config/herdr/plugins/seamless-navigation/dispatch
+++ b/config/herdr/plugins/seamless-navigation/dispatch
@@ -1,0 +1,47 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+if (( $# != 4 )); then
+  print -u2 'usage: dispatch <navigate|resize> <left|down|up|right> <nvim-key> <tmux-key>'
+  exit 2
+fi
+
+mode="$1"
+direction="$2"
+nvim_key="$3"
+tmux_key="$4"
+herdr_bin="${HERDR_BIN_PATH:-herdr}"
+pane_id="${HERDR_ACTIVE_PANE_ID:-${HERDR_PANE_ID:-}}"
+
+if [[ -z "$pane_id" ]]; then
+  pane_id="$($herdr_bin pane current 2>/dev/null | jq -r '.result.pane.pane_id // empty' 2>/dev/null || true)"
+fi
+
+if [[ -z "$pane_id" ]]; then
+  print -u2 'could not determine the active Herdr pane'
+  exit 1
+fi
+
+process_name="$($herdr_bin pane process-info --pane "$pane_id" 2>/dev/null | jq -r '.result.process_info.foreground_processes[0].name // empty' 2>/dev/null || true)"
+
+case "$process_name" in
+  nvim|vim|view|lvim|nvim-*)
+    exec "$herdr_bin" pane send-keys "$pane_id" "$nvim_key"
+    ;;
+  tmux|tmate)
+    exec "$herdr_bin" pane send-keys "$pane_id" "$tmux_key"
+    ;;
+esac
+
+case "$mode" in
+  navigate)
+    exec "$herdr_bin" pane focus --direction "$direction" --pane "$pane_id"
+    ;;
+  resize)
+    exec "$herdr_bin" pane resize --direction "$direction" --pane "$pane_id"
+    ;;
+  *)
+    print -u2 "unknown mode: $mode"
+    exit 2
+    ;;
+esac

--- a/config/herdr/plugins/seamless-navigation/herdr-plugin.toml
+++ b/config/herdr/plugins/seamless-navigation/herdr-plugin.toml
@@ -1,0 +1,54 @@
+id = "dotfiles.seamless-navigation"
+name = "Seamless Navigation"
+version = "0.1.0"
+min_herdr_version = "0.7.4"
+description = "Vim-aware pane navigation and resizing"
+platforms = ["macos", "linux"]
+
+[[actions]]
+id = "navigate-left"
+title = "Navigate left"
+contexts = ["pane"]
+command = ["./dispatch", "navigate", "left", "ctrl+h", "ctrl+h"]
+
+[[actions]]
+id = "navigate-down"
+title = "Navigate down"
+contexts = ["pane"]
+command = ["./dispatch", "navigate", "down", "ctrl+j", "ctrl+j"]
+
+[[actions]]
+id = "navigate-up"
+title = "Navigate up"
+contexts = ["pane"]
+command = ["./dispatch", "navigate", "up", "ctrl+k", "ctrl+k"]
+
+[[actions]]
+id = "navigate-right"
+title = "Navigate right"
+contexts = ["pane"]
+command = ["./dispatch", "navigate", "right", "ctrl+l", "ctrl+l"]
+
+[[actions]]
+id = "resize-left"
+title = "Resize left"
+contexts = ["pane"]
+command = ["./dispatch", "resize", "left", "alt+shift+h", "alt+h"]
+
+[[actions]]
+id = "resize-down"
+title = "Resize down"
+contexts = ["pane"]
+command = ["./dispatch", "resize", "down", "alt+shift+j", "alt+j"]
+
+[[actions]]
+id = "resize-up"
+title = "Resize up"
+contexts = ["pane"]
+command = ["./dispatch", "resize", "up", "alt+shift+k", "alt+k"]
+
+[[actions]]
+id = "resize-right"
+title = "Resize right"
+contexts = ["pane"]
+command = ["./dispatch", "resize", "right", "alt+shift+l", "alt+l"]

--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -19,6 +19,7 @@
   "grapple.nvim": { "branch": "main", "commit": "b41ddfc1c39f87f3d1799b99c2f0f1daa524c5f7" },
   "grug-far.nvim": { "branch": "main", "commit": "1cc080f55706b38aabfa97d40acb6adf59ac4a5a" },
   "gx.nvim": { "branch": "main", "commit": "ba9c408fc0130fc4548760c3933a81b58fc50de8" },
+  "herdr-navigator.nvim": { "branch": "main", "commit": "e6b05e6f99b4f99df42cd7e78ae33a066351138d" },
   "hex.vim": { "branch": "master", "commit": "28f9c4d2c14e4406f30f16f7a720f0457df8dd1a" },
   "kulala.nvim": { "branch": "main", "commit": "91cf892008c773ce74ac392c4c12ddff775b7619" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },

--- a/config/nvim/lua/core/mappings.lua
+++ b/config/nvim/lua/core/mappings.lua
@@ -68,6 +68,7 @@ local tmux = function(fun)
 end
 
 local silent = { silent = true }
+local is_herdr = utils.in_herdr()
 
 -- a more useful gf
 nmap { 'gf', 'gF', { desc = 'Go to file under cursor', silent = true } }
@@ -112,55 +113,47 @@ vmap { '<', '<gv' }
 -- Search for selected text
 vmap { '*', '"xy/<C-R>x<CR>' }
 
---  Navigate neovim + tmux with ctrl+direction
-vmap { '<C-h>', tmux 'move_left', { desc = 'Move to left pane' } }
-vmap { '<C-j>', tmux 'move_bottom', { desc = 'Move to bottom pane' } }
-vmap { '<C-k>', tmux 'move_top', { desc = 'Move to top pane' } }
-vmap { '<C-l>', tmux 'move_right', { desc = 'Move to right pane' } }
+if not is_herdr then
+  -- Navigate neovim + tmux with ctrl+direction
+  vmap { '<C-h>', tmux 'move_left', { desc = 'Move to left pane' } }
+  vmap { '<C-j>', tmux 'move_bottom', { desc = 'Move to bottom pane' } }
+  vmap { '<C-k>', tmux 'move_top', { desc = 'Move to top pane' } }
+  vmap { '<C-l>', tmux 'move_right', { desc = 'Move to right pane' } }
 
---  Navigate neovim + neovim terminal emulator + tmux with ctrl+direction
-tmap { '<C-h>', tmux 'move_left' }
-tmap { '<C-j>', tmux 'move_bottom' }
-tmap { '<C-k>', tmux 'move_top' }
-tmap { '<C-l>', tmux 'move_right' }
+  -- Navigate neovim + neovim terminal emulator + tmux with ctrl+direction
+  tmap { '<C-h>', tmux 'move_left' }
+  tmap { '<C-j>', tmux 'move_bottom' }
+  tmap { '<C-k>', tmux 'move_top' }
+  tmap { '<C-l>', tmux 'move_right' }
+end
 
 -- easily escape terminal
 tmap { '<esc><esc>', '<C-\\><C-n><esc><cr>' }
 tmap { '<C-o>', '<C-\\><C-n><esc><cr>' }
 
--- resize windows with alt+hjkl in terminal mode (matches tmux behavior)
-tmap {
-  '<M-h>',
-  function()
-    require('core.tmux_resizer').resize_left()
+for _, resize in ipairs {
+  { key = 'h', direction = 'left' },
+  { key = 'j', direction = 'down' },
+  { key = 'k', direction = 'up' },
+  { key = 'l', direction = 'right' },
+} do
+  local direction = resize.direction
+  local resize_pane = function()
+    require('core.tmux_resizer')['resize_' .. direction]()
+  end
+  local terminal_resize = function()
+    resize_pane()
     vim.cmd 'startinsert'
-  end,
-  silent,
-}
-tmap {
-  '<M-j>',
-  function()
-    require('core.tmux_resizer').resize_down()
-    vim.cmd 'startinsert'
-  end,
-  silent,
-}
-tmap {
-  '<M-k>',
-  function()
-    require('core.tmux_resizer').resize_up()
-    vim.cmd 'startinsert'
-  end,
-  silent,
-}
-tmap {
-  '<M-l>',
-  function()
-    require('core.tmux_resizer').resize_right()
-    vim.cmd 'startinsert'
-  end,
-  silent,
-}
+  end
+
+  if is_herdr then
+    local key = '<M-' .. resize.key:upper() .. '>'
+    vim.keymap.set({ 'n', 'x', 's' }, key, resize_pane, { desc = 'Resize ' .. direction })
+    vim.keymap.set('t', key, terminal_resize, { desc = 'Resize ' .. direction })
+  else
+    tmap { '<M-' .. resize.key .. '>', terminal_resize, silent }
+  end
+end
 
 -- close all other windows with <leader>o
 nmap { '<leader>wo', '<c-w>o', { desc = 'Close other windows' } }

--- a/config/nvim/lua/core/tmux_resizer.lua
+++ b/config/nvim/lua/core/tmux_resizer.lua
@@ -2,6 +2,7 @@
 -- Based on RyanMillerC/better-vim-tmux-resizer
 
 local M = {}
+local utils = require 'core.utils'
 
 -- Configuration
 M.config = {
@@ -12,6 +13,10 @@ M.config = {
 -- Check if we're in tmux
 local function in_tmux()
   return vim.env.TMUX ~= nil
+end
+
+local function in_herdr()
+  return utils.in_herdr()
 end
 
 -- Get tmux executable (tmux or tmate)
@@ -34,6 +39,17 @@ local function tmux_command(args)
 
   local cmd = string.format('%s -S %s %s', tmux_executable(), tmux_socket(), args)
   vim.fn.system(cmd)
+end
+
+local function herdr_resize(direction)
+  local args = { vim.env.HERDR_BIN_PATH or 'herdr', 'pane', 'resize', '--direction', direction }
+  local pane_id = vim.env.HERDR_PANE_ID
+  if pane_id and pane_id ~= '' then
+    vim.list_extend(args, { '--pane', pane_id })
+  else
+    args[#args + 1] = '--current'
+  end
+  vim.system(args, { text = true }, function() end)
 end
 
 -- Vim window resize logic
@@ -78,16 +94,22 @@ local function vim_resize(direction)
   vim.cmd(command .. ' ' .. modifier .. window_resize_count)
 end
 
--- Tmux-aware resize function
-local function tmux_aware_resize(direction)
+-- Multiplexer-aware resize function
+local function multiplexer_aware_resize(direction)
   local previous_window_width = vim.fn.winwidth(0)
   local previous_window_height = vim.fn.winheight(0)
 
   -- Attempt to resize Vim window
   vim_resize(direction)
 
-  -- Call tmux if Vim window dimensions did not change
+  -- Resize the surrounding multiplexer pane if the Vim window did not change.
   if previous_window_height == vim.fn.winheight(0) and previous_window_width == vim.fn.winwidth(0) then
+    local directions = { h = 'left', j = 'down', k = 'up', l = 'right' }
+    if in_herdr() then
+      herdr_resize(directions[direction])
+      return
+    end
+
     local resize_count
     if direction == 'h' or direction == 'l' then
       resize_count = M.config.vertical_resize_count
@@ -110,32 +132,32 @@ end
 
 -- Public API functions
 function M.resize_left()
-  if in_tmux() then
-    tmux_aware_resize 'h'
+  if in_tmux() or in_herdr() then
+    multiplexer_aware_resize 'h'
   else
     vim_resize 'h'
   end
 end
 
 function M.resize_down()
-  if in_tmux() then
-    tmux_aware_resize 'j'
+  if in_tmux() or in_herdr() then
+    multiplexer_aware_resize 'j'
   else
     vim_resize 'j'
   end
 end
 
 function M.resize_up()
-  if in_tmux() then
-    tmux_aware_resize 'k'
+  if in_tmux() or in_herdr() then
+    multiplexer_aware_resize 'k'
   else
     vim_resize 'k'
   end
 end
 
 function M.resize_right()
-  if in_tmux() then
-    tmux_aware_resize 'l'
+  if in_tmux() or in_herdr() then
+    multiplexer_aware_resize 'l'
   else
     vim_resize 'l'
   end

--- a/config/nvim/lua/core/utils.lua
+++ b/config/nvim/lua/core/utils.lua
@@ -1,5 +1,10 @@
 local M = {}
 
+function M.in_herdr()
+  return vim.env.TMUX == nil
+    and (vim.env.HERDR_SESSION ~= nil or vim.env.HERDR_PANE_ID ~= nil or vim.env.HERDR_ENV ~= nil)
+end
+
 -- Load project specific vimrc
 function M.load_local_vimrc()
   local cwd = vim.fn.getcwd()

--- a/config/nvim/lua/plugins/herdr-navigator.lua
+++ b/config/nvim/lua/plugins/herdr-navigator.lua
@@ -1,0 +1,34 @@
+local keys = {}
+
+for _, navigation in ipairs {
+  { name = 'left', key = '<C-h>', vim_direction = 'h' },
+  { name = 'down', key = '<C-j>', vim_direction = 'j' },
+  { name = 'up', key = '<C-k>', vim_direction = 'k' },
+  { name = 'right', key = '<C-l>', vim_direction = 'l' },
+} do
+  local name = navigation.name
+  local vim_direction = navigation.vim_direction
+  keys[#keys + 1] = {
+    navigation.key,
+    function()
+      require('herdr-navigator')[name]()
+    end,
+    mode = { 'n', 'x', 's' },
+    desc = 'Navigate ' .. name,
+  }
+  keys[#keys + 1] = {
+    navigation.key,
+    function()
+      require('herdr-navigator').navigate_terminal(vim_direction, name)
+    end,
+    mode = 't',
+    desc = 'Navigate ' .. name,
+  }
+end
+
+---@type LazySpec
+return {
+  'willfish/herdr-navigator.nvim',
+  cond = require('core.utils').in_herdr(),
+  keys = keys,
+}

--- a/config/nvim/lua/plugins/tmux.lua
+++ b/config/nvim/lua/plugins/tmux.lua
@@ -2,6 +2,7 @@
 ---@type LazySpec
 return {
   'aserowy/tmux.nvim',
+  cond = not require('core.utils').in_herdr(),
   event = 'VeryLazy',
   opts = {
     copy_sync = {

--- a/taskfiles/dotfiles.yml
+++ b/taskfiles/dotfiles.yml
@@ -1,11 +1,6 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 version: '3'
 
-vars:
-  HERDR_PLUGINS:
-    map:
-      gh-pr: 'wyattjoh/herdr-plugin-gh-pr'
-
 includes:
   1password:
     taskfile: ./1password.yaml
@@ -39,6 +34,11 @@ includes:
 
   gh:
     taskfile: ./github.yml
+    internal: true
+
+  herdr:
+    taskfile: ./herdr.yml
+    dir: ../
     internal: true
 
   mac:
@@ -174,31 +174,6 @@ tasks:
     cmds:
       - mise bootstrap dotfiles apply --yes
       - task: skills:sync
-
-  herdr:plugins:install:
-    desc: Installs Herdr plugins
-    cmds:
-      - for:
-          var: HERDR_PLUGINS
-        cmd: |
-          set -eu
-
-          installed="$(herdr plugin list --plugin '{{.KEY}}' --json | jq '.result.plugins | length')"
-          if [ "$installed" -eq 0 ]; then
-            herdr plugin install '{{.ITEM}}' --yes >/dev/null
-          fi
-        silent: true
-
-  herdr:plugins:sync:
-    desc: Installs Herdr plugins and registers repo-managed plugins
-    cmds:
-      - task: herdr:plugins:install
-      - cmd: |
-          set -eu
-
-          plugin="$(realpath ./config/herdr/plugins/command-palette)"
-          herdr plugin unlink dotfiles.command-palette >/dev/null 2>&1 || true
-          herdr plugin link "$plugin" >/dev/null
 
   skills:sync:
     desc: Synchronizes repo and local skills into global skill directories

--- a/taskfiles/herdr.yml
+++ b/taskfiles/herdr.yml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: 3
+
+vars:
+  PLUGINS:
+    map:
+      gh-pr: 'wyattjoh/herdr-plugin-gh-pr'
+  LOCAL_PLUGINS:
+    map:
+      dotfiles.command-palette: command-palette
+      dotfiles.seamless-navigation: seamless-navigation
+
+tasks:
+  plugins:install:
+    desc: Installs Herdr plugins
+    cmds:
+      - for:
+          var: PLUGINS
+        cmd: |
+          set -eu
+
+          installed="$(herdr plugin list --plugin '{{.KEY}}' --json | jq '.result.plugins | length')"
+          if [ "$installed" -eq 0 ]; then
+            herdr plugin install '{{.ITEM}}' --yes >/dev/null
+          fi
+        silent: true
+
+  plugins:sync:
+    desc: Installs Herdr plugins and registers repo-managed plugins
+    cmds:
+      - task: plugins:install
+      - for:
+          var: LOCAL_PLUGINS
+        cmd: |
+          set -eu
+
+          plugin="$(realpath './config/herdr/plugins/{{.ITEM}}')"
+          herdr plugin unlink '{{.KEY}}' >/dev/null 2>&1 || true
+          herdr plugin link "$plugin" >/dev/null


### PR DESCRIPTION
# Motivation

Use the same navigation and resize keys across Neovim, Herdr, and tmux without making the integrations compete for mappings.

# Summary of Changes

- Add a local Herdr plugin that routes navigation and resize keys based on the pane's foreground process, including nested tmux sessions.
- Load `herdr-navigator.nvim` only in direct Herdr panes and extend the existing Neovim resizer to fall back to Herdr at split edges.
- Move Herdr plugin installation and portable local-plugin linking into `taskfiles/herdr.yml`.

# Testing

- Run `task ci:run`.
- Run `task herdr:plugins:sync` and confirm the command palette, PR status, and seamless navigation plugins are registered.
- In a Herdr-hosted Neovim session, use `Ctrl+h/j/k/l` to cross split and pane boundaries, then use `Alt+h/j/k/l` to resize splits and panes.
- Outside Herdr, confirm the existing tmux navigation and resize mappings still work.

# Dependencies/Special Considerations

Requires Herdr 0.7.4 or newer. The existing Mise configuration provides `jq`, which the local dispatcher uses for process detection.