### PR TITLE
feat: use vellum for herdr workspace picker

### DIFF
--- a/config/herdr/plugins/command-palette/workspace-picker
+++ b/config/herdr/plugins/command-palette/workspace-picker
@@ -1,6 +1,15 @@
 #!/usr/bin/env zsh
 set -euo pipefail
 
-export PATH="$HOME/dotfiles/bin:$HOME/.local/share/mise/shims:$PATH"
+export PATH="$HOME/.local/share/mise/shims:$PATH"
 
-exec tv herdr-workspaces --layout portrait --no-preview --no-status-bar --no-remote
+# Vellum 0.4.1 writes both its TUI and selection to stdout. Mirror the TUI back
+# to the terminal, then extract the opaque selection after it restores the screen.
+output="$(vellum herdr-workspaces | tee /dev/tty)"
+alternate_screen_end=$'\e[?1049l'
+
+[[ "$output" == *"$alternate_screen_end"* ]] || exit 1
+workspace_id="${output##*"$alternate_screen_end"}"
+[[ -n "$workspace_id" ]] || exit 0
+
+exec "${HERDR_BIN_PATH:-herdr}" workspace focus "$workspace_id"

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -37,6 +37,7 @@
 "github:chmln/sd" = "latest"          # a modern alternative for sed with sensible defaults
 "github:cli/cli" = "latest"           # GitHub CLI
 "github:dkarter/lnr" = "latest"       # linear cli
+"github:dkarter/vellum" = "latest"    # a better tool for command palettes
 "github:dlvhdr/diffnav" = "latest"    # A git diff pager based on delta but with a file tree, à la GitHub.
 "github:joshmedeski/sesh" = "latest"  # tmux session manager
 "github:mazznoer/lolcrab" = "latest"  # like lolcat, but written in Rust and with more features
@@ -148,4 +149,5 @@ minimum_release_age_excludes = [
   "elixir",
   "github:dkarter/lnr",
   "github:dkarter/vstui",
+  "github:dkarter/vellum",
 ]

--- a/config/mise/mise.lock
+++ b/config/mise/mise.lock
@@ -1254,6 +1254,65 @@ url = "https://github.com/dkarter/lnr/releases/download/v3.0.1/lnr_3.0.1_windows
 url_api = "https://api.github.com/repos/dkarter/lnr/releases/assets/490777747"
 provenance = "github-attestations"
 
+[[tools."github:dkarter/vellum"]]
+version = "0.4.1"
+backend = "github:dkarter/vellum"
+
+[tools."github:dkarter/vellum"."platforms.linux-arm64"]
+checksum = "sha256:c5bd536a85f77c4ed6f6370cf8ebc4440ea2cce74147c9f02b72754916828d01"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990715"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.linux-arm64-musl"]
+checksum = "sha256:c5bd536a85f77c4ed6f6370cf8ebc4440ea2cce74147c9f02b72754916828d01"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990715"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.linux-x64"]
+checksum = "sha256:3339e4fec30ee008561bcf0641937a624ee58dd4428e87d609435fc9f06774ba"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990954"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.linux-x64-baseline"]
+checksum = "sha256:3339e4fec30ee008561bcf0641937a624ee58dd4428e87d609435fc9f06774ba"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990954"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.linux-x64-musl"]
+checksum = "sha256:3339e4fec30ee008561bcf0641937a624ee58dd4428e87d609435fc9f06774ba"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990954"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:3339e4fec30ee008561bcf0641937a624ee58dd4428e87d609435fc9f06774ba"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990954"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.macos-arm64"]
+checksum = "sha256:3ae7b64da96019bdff688b8cdd4601c5c3dac9ef5f2aea5c66afb39a074fb5fa"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490990271"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools."github:dkarter/vellum"."platforms.windows-x64"]
+checksum = "sha256:1354d76d0789139c32b6a41d63395d4a26b084976ed52f7c8bed19feb568e74a"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_windows_x86_64.zip"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490991014"
+provenance = "github-attestations"
+
+[tools."github:dkarter/vellum"."platforms.windows-x64-baseline"]
+checksum = "sha256:1354d76d0789139c32b6a41d63395d4a26b084976ed52f7c8bed19feb568e74a"
+url = "https://github.com/dkarter/vellum/releases/download/v0.4.1/vellum_0.4.1_windows_x86_64.zip"
+url_api = "https://api.github.com/repos/dkarter/vellum/releases/assets/490991014"
+provenance = "github-attestations"
+
 [[tools."github:dlvhdr/diffnav"]]
 version = "0.12.0"
 backend = "github:dlvhdr/diffnav"

--- a/config/vellum/palettes/herdr-workspaces.toml
+++ b/config/vellum/palettes/herdr-workspaces.toml
@@ -1,0 +1,34 @@
+#:schema https://raw.githubusercontent.com/dkarter/vellum/refs/heads/main/schemas/vellum.schema.json
+
+[search]
+title = "Workspaces"
+placeholder = "Switch workspace..."
+
+[source]
+builtin = "herdr-workspaces"
+refresh_ms = 1000
+
+[item]
+value = "$workspace_id"
+template = [
+  [
+    { token = "$label", fg = "$focus_color", bold = true },
+    { token = "$status_icon", fg = "$status_color", searchable = false, align = "right" },
+    " ",
+    { token = "$agent_status", fg = "$status_color", searchable = false, align = "right" },
+  ],
+  [
+    { token = "󰉋 ", fg = "#7dcfff", searchable = false },
+    { token = "$checkout_path", fg = "#a9b1d6" },
+  ],
+]
+
+[theme]
+foreground = "#c0caf5"
+background = "#1a1b26"
+selection_foreground = "#c0caf5"
+selection_background = "#283457"
+border = "#565f89"
+mode_foreground = "#1a1b26"
+insert_mode_background = "#9ece6a"
+normal_mode_background = "#e0af68"


### PR DESCRIPTION
# Motivation

Use Vellum for the Herdr workspace popup while keeping the existing Television channel available.

# Summary of changes

- Install `dkarter/vellum` through Mise.
- Add Vellum's official Herdr workspace palette.
- Send Vellum's TUI output back to the popup terminal and focus the selected workspace.

# Testing

- Run `task sync`.
- Open the Herdr workspace picker and confirm the workspace list is visible.
- Select a workspace and confirm Herdr focuses it.
- Run `task ci:run`.

# Dependencies/Special considerations

None.